### PR TITLE
gate checks heartbeat

### DIFF
--- a/engine/consts/consts.go
+++ b/engine/consts/consts.go
@@ -47,7 +47,7 @@ const (
 	GATE_SERVICE_PACKET_QUEUE_SIZE = 10000
 	// GATE_SERVICE_TICK_INTERVAL is the tick interval to tick timers in gate service
 	GATE_SERVICE_TICK_INTERVAL           = time.Millisecond * 5 // server tick interval => affect timer resolution
-	GATE_SERVICE_HEARTBEAT_TICK_INTERVAL = time.Second * 3      // server tick interval => affect timer resolution
+	GATE_SERVICE_HEARTBEAT_TICK_INTERVAL = time.Second * 3      // server heartbeat tick interval => affect timer resolution
 	// CLIENT_PROXY_WRITE_BUFFER_SIZE is the write buffer size for gates' client proxies
 	CLIENT_PROXY_WRITE_BUFFER_SIZE = 1024 * 1024
 	// CLIENT_PROXY_READ_BUFFER_SIZE is the read buffer size for gates' client proxies

--- a/engine/consts/consts.go
+++ b/engine/consts/consts.go
@@ -46,7 +46,8 @@ const (
 	// GATE_SERVICE_PACKET_QUEUE_SIZE is the packet queue size of gate service
 	GATE_SERVICE_PACKET_QUEUE_SIZE = 10000
 	// GATE_SERVICE_TICK_INTERVAL is the tick interval to tick timers in gate service
-	GATE_SERVICE_TICK_INTERVAL = time.Millisecond * 5 // server tick interval => affect timer resolution
+	GATE_SERVICE_TICK_INTERVAL           = time.Millisecond * 5 // server tick interval => affect timer resolution
+	GATE_SERVICE_HEARTBEAT_TICK_INTERVAL = time.Millisecond * 5 // server tick interval => affect timer resolution
 	// CLIENT_PROXY_WRITE_BUFFER_SIZE is the write buffer size for gates' client proxies
 	CLIENT_PROXY_WRITE_BUFFER_SIZE = 1024 * 1024
 	// CLIENT_PROXY_READ_BUFFER_SIZE is the read buffer size for gates' client proxies

--- a/engine/consts/consts.go
+++ b/engine/consts/consts.go
@@ -47,7 +47,7 @@ const (
 	GATE_SERVICE_PACKET_QUEUE_SIZE = 10000
 	// GATE_SERVICE_TICK_INTERVAL is the tick interval to tick timers in gate service
 	GATE_SERVICE_TICK_INTERVAL           = time.Millisecond * 5 // server tick interval => affect timer resolution
-	GATE_SERVICE_HEARTBEAT_TICK_INTERVAL = time.Millisecond * 5 // server tick interval => affect timer resolution
+	GATE_SERVICE_HEARTBEAT_TICK_INTERVAL = time.Second * 3      // server tick interval => affect timer resolution
 	// CLIENT_PROXY_WRITE_BUFFER_SIZE is the write buffer size for gates' client proxies
 	CLIENT_PROXY_WRITE_BUFFER_SIZE = 1024 * 1024
 	// CLIENT_PROXY_READ_BUFFER_SIZE is the read buffer size for gates' client proxies


### PR DESCRIPTION
1. gate server 可能會因爲 client 退背景或是切換網路導致 socket buffer 滿了而無法送封包卡住
  => heartbeat 機制看起來沒做完，新增 ticker 每三秒檢查一次 heartbeat，如果大於 config HeartbeatCheckInterval 沒有封包則斷掉線
2. 封包量太大的時候還是有機會卡住
  可能解決方向：
   - 增加 tcp socket 的 send buffer size
   - 如果 buffer 滿了，不繼續送封包

